### PR TITLE
Tested the new subroutines

### DIFF
--- a/era_computerel.m
+++ b/era_computerel.m
@@ -77,6 +77,9 @@ function RELout = era_computerel(varargin)
 %7/19/16 PC
 % Changes associate with updating to cmdstan-2.10.0
 %  changed <- to = (<- is not deprecated)
+%
+%7/28/16 PC
+% Added defineversion function
 
 %somersault through varargin inputs to check for which inputs were
 %defined and store those values. 
@@ -141,7 +144,7 @@ elseif isempty(varargin)
     
 end %if ~isempty(varargin)
 
-eraver = '0.3.2';
+eraver = era_defineversion;
 
 %store raw data to pass to era_checkconvergence in the event that the user
 %chooses to run with more iterations

--- a/era_startproc.m
+++ b/era_startproc.m
@@ -45,6 +45,9 @@ function era_startproc(varargin)
 %
 %7/22/16 PC 
 % Pulling out subroutines
+%
+%7/28/16 PC
+% Missed a change related to era_data structure
 
 %check if era_gui is open. If the user executes era_startproc and skips
 %era_start then there will be no gui to close.
@@ -556,8 +559,8 @@ ind = find(ismember(bin, multiple));
 if ~isempty(ind)
     probcol = {};
     for i = 1:length(ind)
-        if choices(ind(i)) ~= length(collist)
-            probcol(end+1) = collist(ind(i));
+        if choices(ind(i)) ~= length(era_data.proc.collist)
+            probcol(end+1) = era_data.proc.collist(ind(i));
         end
     end
     if ~isempty(probcol)

--- a/era_startview.m
+++ b/era_startview.m
@@ -4,7 +4,7 @@ function era_startview(varargin)
 %
 %era_startview('file','/Users/REL/SomeERAData.mat')
 %
-%Last Updated 7/26/16
+%Last Updated 7/27/16
 %
 %Required Inputs:
 % No inputs are required.
@@ -59,6 +59,9 @@ function era_startview(varargin)
 %7/26/16 PC
 % added check to make sure that at least 2 trials were requested for the
 %  number of trials and dependability plot
+%
+%7/27/16 PC
+% got rid of some code that was no longer used
 
 %somersault through varargin inputs to check for era_prefs and era_data
 [era_prefs, era_data] = era_findprefsdata(varargin);
@@ -352,10 +355,7 @@ if depeval ~= 0
     %check if era_gui is open.
     era_gui = findobj('Tag','era_gui');
     if ~isempty(era_gui)
-        pos = era_gui.Position;
         close(era_gui);
-    else
-        pos=[400 400 550 550];
     end
     
     %create error text

--- a/era_startview.m
+++ b/era_startview.m
@@ -4,7 +4,7 @@ function era_startview(varargin)
 %
 %era_startview('file','/Users/REL/SomeERAData.mat')
 %
-%Last Updated 7/24/16
+%Last Updated 7/26/16
 %
 %Required Inputs:
 % No inputs are required.
@@ -55,6 +55,10 @@ function era_startview(varargin)
 %
 %7/24/16 PC
 % use era_data as input into era_relfigures
+%
+%7/26/16 PC
+% added check to make sure that at least 2 trials were requested for the
+%  number of trials and dependability plot
 
 %somersault through varargin inputs to check for era_prefs and era_data
 [era_prefs, era_data] = era_findprefsdata(varargin);
@@ -397,37 +401,40 @@ function era_viewprefs(varargin)
 
 %find inputs
 ind = find(strcmp('inputs',varargin),1);
-inputs = varargin{ind+1};
 
-%check whether the dependability estimate provided is numeric and between 0
-%and 1
-depeval = depcheck(str2double(inputs.h(1).String));
+if ~isempty(ind)
+    inputs = varargin{ind+1};
 
-%if the dependability estimate was not numeric or between 0 and 1, give the
-%user an error and take the user back.
-if depeval ~= 0 
-    %create error text
-    errorstr = {};
-    errorstr{end+1} = 'The dependability estimate must be numeric';
-    errorstr{end+1} = 'and between 0 and 1 (inclusive)';
-    
-    %display error prompt
-    errordlg(errorstr);
-    
-    %execute era_startview_fig with the new preferences
-    era_startview_fig(h_view_gui.filename,h_view_gui.pathname,'inputs',...
-        h_view_gui.inputs,'viewprefs',initialprefs);
-    
-    return;
+    %check whether the dependability estimate provided is numeric and between 0
+    %and 1
+    depeval = depcheck(str2double(inputs.h(1).String));
+
+    %if the dependability estimate was not numeric or between 0 and 1, give the
+    %user an error and take the user back.
+    if depeval ~= 0 
+        %create error text
+        errorstr = {};
+        errorstr{end+1} = 'The dependability estimate must be numeric';
+        errorstr{end+1} = 'and between 0 and 1 (inclusive)';
+
+        %display error prompt
+        errordlg(errorstr);
+
+        %execute era_startview_fig with the new preferences
+        era_startview_fig(h_view_gui.filename,h_view_gui.pathname,'inputs',...
+            h_view_gui.inputs,'viewprefs',initialprefs);
+
+        return;
+    end
+
+    era_prefs.view.depvalue = str2double(inputs.h(1).String);
+    era_prefs.view.plotdep = inputs.h(2).Value;
+    era_prefs.view.ploticc = inputs.h(3).Value;
+    era_prefs.view.inctrltable = inputs.h(4).Value;
+    era_prefs.view.overalltable = inputs.h(5).Value;
+    era_prefs.view.showstddevt = inputs.h(6).Value;
+    era_prefs.view.showstddevf = inputs.h(7).Value;
 end
-
-era_prefs.view.depvalue = str2double(inputs.h(1).String);
-era_prefs.view.plotdep = inputs.h(2).Value;
-era_prefs.view.ploticc = inputs.h(3).Value;
-era_prefs.view.inctrltable = inputs.h(4).Value;
-era_prefs.view.overalltable = inputs.h(5).Value;
-era_prefs.view.showstddevt = inputs.h(6).Value;
-era_prefs.view.showstddevf = inputs.h(7).Value;
 
 %check if era_gui is open.
 era_gui = findobj('Tag','era_gui');
@@ -593,8 +600,20 @@ if ~isempty(era_gui)
     close(era_gui);
 end
 
-%execute era_startview_fig with the new preferences
-era_startview_fig('era_prefs',era_prefs,'era_data',era_data);
+if era_prefs.view.ntrials > 1
+    %execute era_startview_fig with the new preferences
+    era_startview_fig('era_prefs',era_prefs,'era_data',era_data);
+end
+
+%make sure the user has defined at least 2 trials to plot for the figure
+if era_prefs.view.ntrials <= 1 
+    errordlg(['Please specify at least two trials to plot ', ...
+        'for dependability estimates']);
+    era_prefs.view.ntrials = 50;
+
+    era_viewprefs('era_prefs',era_prefs,'era_data',era_data);
+    
+end
 
 end
 

--- a/subroutines/era_computerelwrap.m
+++ b/subroutines/era_computerelwrap.m
@@ -38,6 +38,9 @@ function era_data = era_computerelwrap(varargin)
 %History 
 % by Peter Clayson (7/22/16)
 % peter.clayson@gmail.com
+%
+%7/26/16 PC
+% bug fix: not able to execute era_startproc_gui directly
 
 %pull era_prefs and era_data from varargin
 [era_prefs, era_data] = era_findprefsdata(varargin);
@@ -203,7 +206,7 @@ end
 %if the chains did not converge send the user back to era_startproc_gui
 if RELout.out.conv.converged == 0
 
-    era_startproc_gui('era_path',era_path,'era_data',era_data);
+    era_startproc('era_path',era_path,'era_data',era_data);
     return
     
 else

--- a/subroutines/era_computerelwrap.m
+++ b/subroutines/era_computerelwrap.m
@@ -206,7 +206,7 @@ end
 %if the chains did not converge send the user back to era_startproc_gui
 if RELout.out.conv.converged == 0
 
-    era_startproc('era_path',era_path,'era_data',era_data);
+    era_startproc('era_prefs',era_prefs,'era_data',era_data);
     return
     
 else

--- a/subroutines/era_computerelwrap.m
+++ b/subroutines/era_computerelwrap.m
@@ -41,6 +41,9 @@ function era_data = era_computerelwrap(varargin)
 %
 %7/26/16 PC
 % bug fix: not able to execute era_startproc_gui directly
+%
+%7/28/16 PC
+% fixed typo causing era_start not to execute after failing to converge
 
 %pull era_prefs and era_data from varargin
 [era_prefs, era_data] = era_findprefsdata(varargin);


### PR DESCRIPTION
I pulled out the subroutines for the reliability analyses and plotting. They were tested for each possible combination of group and event as facets on Windows and Mac. 

## Description
Many subroutines were pulled out of the era_relfigures.m script. This should make things smoother for using the toolbox from the CLI. Going back to my roots! 

## Related Issue
No related issue

## Motivation and Context
Make life easier to use toolbox from CLI

## How Has This Been Tested?
Tested on Windows 7 and Mac OS 10.11.16 in Matlab 2014b and 2015b.
Tested with data that had group and event as facets. Ran with each possible combination.
The affected areas of code are the functions involved in calculating reliability estimates and displaying information.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [x] My code follows the code style of this project.
- [x] My code has been commented in the Matlab scripts.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
